### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/SP-Framework/overview/sharepoint.md
+++ b/SP-Framework/overview/sharepoint.md
@@ -13,8 +13,8 @@ The SharePoint Framework object model is built in TypeScript. Use this section t
 
 ## See also
 
-- [Overview of SharePoint Framework](https://docs.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview)
-- [Getting started with SharePoint Framework web parts](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part)
-- [Getting started with SharePoint Framework Extensions](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/get-started/build-a-hello-world-extension)
-- [Overview of Viva Connections Extensibility](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/viva/overview-viva-connections)
-- [Build for Microsoft Teams using SharePoint Framework](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/build-for-teams-overview)
+- [Overview of SharePoint Framework](/sharepoint/dev/spfx/sharepoint-framework-overview)
+- [Getting started with SharePoint Framework web parts](/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part)
+- [Getting started with SharePoint Framework Extensions](/sharepoint/dev/spfx/extensions/get-started/build-a-hello-world-extension)
+- [Overview of Viva Connections Extensibility](/sharepoint/dev/spfx/viva/overview-viva-connections)
+- [Build for Microsoft Teams using SharePoint Framework](/sharepoint/dev/spfx/build-for-teams-overview)

--- a/SP-Framework/sp-http/aadhttpclientfactory.yml
+++ b/SP-Framework/sp-http/aadhttpclientfactory.yml
@@ -5,7 +5,7 @@ package: '@microsoft/sp-http!'
 fullName: AadHttpClientFactory
 summary: >-
   Returns a preinitialized version of the AadHttpClient for a given resource url. For more information:
-  [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-aadhttpclient](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-aadhttpclient)
+  [Connect to Azure AD-secured APIs in SharePoint Framework solutions](/sharepoint/dev/spfx/use-aadhttpclient)
 remarks: >-
   The constructor for this class is marked as internal. Third-party code should not call the constructor directly or
   create subclasses that extend the `AadHttpClientFactory` class.

--- a/SP-Framework/sp-http/msgraphclientfactory.yml
+++ b/SP-Framework/sp-http/msgraphclientfactory.yml
@@ -5,7 +5,7 @@ package: '@microsoft/sp-http!'
 fullName: MSGraphClientFactory
 summary: >-
   Returns a preinitialized version of the MSGraphClient. For more information:
-  [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-msgraph](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-msgraph)
+  [Use the MSGraphClient to connect to Microsoft Graph](/sharepoint/dev/spfx/use-msgraph)
 remarks: >-
   The constructor for this class is marked as internal. Third-party code should not call the constructor directly or
   create subclasses that extend the `MSGraphClientFactory` class.

--- a/SP-Framework/sp-webpart-base/imicrosoftteams.yml
+++ b/SP-Framework/sp-webpart-base/imicrosoftteams.yml
@@ -16,7 +16,7 @@ properties:
     summary: Microsoft Teams' Context.
     remarks: >-
       For more information, please see:
-      [https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/microsoftteams.context?view=msteams-client-js-latest](https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/microsoftteams.context?view=msteams-client-js-latest)
+      [Context interface](/javascript/api/@microsoft/teams-js/microsoftteams.context?view=msteams-client-js-latest)
     isPreview: false
     isDeprecated: false
     syntax:

--- a/SP-Framework/sp-webpart-base/isdks.yml
+++ b/SP-Framework/sp-webpart-base/isdks.yml
@@ -18,7 +18,7 @@ properties:
       being hosted in Microsoft Teams.
     remarks: >-
       For more information, please see:
-      [https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest](https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
+      [`@microsoft/teams-js` package](/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
     isPreview: false
     isDeprecated: false
     syntax:

--- a/SP-Framework/sp-webpart-base/webpartcontext.yml
+++ b/SP-Framework/sp-webpart-base/webpartcontext.yml
@@ -34,7 +34,7 @@ properties:
       being hosted in Microsoft Teams.
     remarks: >-
       For more information, please see:
-      [https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest](https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
+      [`@microsoft/teams-js` package](/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
     isPreview: false
     isDeprecated: true
     customDeprecatedMessage: '- This function has been deprecated'


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
