### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/SP-Framework/overview/sharepoint.md
+++ b/SP-Framework/overview/sharepoint.md
@@ -13,8 +13,8 @@ The SharePoint Framework object model is built in TypeScript. Use this section t
 
 ## See also
 
-- [Overview of SharePoint Framework](https://docs.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview)
-- [Getting started with SharePoint Framework web parts](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part)
-- [Getting started with SharePoint Framework Extensions](https://docs.microsoft.com/sharepoint/dev/spfx/extensions/get-started/build-a-hello-world-extension)
-- [Overview of Viva Connections Extensibility](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/viva/overview-viva-connections)
-- [Build for Microsoft Teams using SharePoint Framework](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/build-for-teams-overview)
+- [Overview of SharePoint Framework](https://learn.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview)
+- [Getting started with SharePoint Framework web parts](https://learn.microsoft.com/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part)
+- [Getting started with SharePoint Framework Extensions](https://learn.microsoft.com/sharepoint/dev/spfx/extensions/get-started/build-a-hello-world-extension)
+- [Overview of Viva Connections Extensibility](https://learn.microsoft.com/sharepoint/dev/spfx/viva/overview-viva-connections)
+- [Build for Microsoft Teams using SharePoint Framework](https://learn.microsoft.com/sharepoint/dev/spfx/build-for-teams-overview)

--- a/SP-Framework/sp-http/aadhttpclientfactory.yml
+++ b/SP-Framework/sp-http/aadhttpclientfactory.yml
@@ -5,7 +5,7 @@ package: '@microsoft/sp-http!'
 fullName: AadHttpClientFactory
 summary: >-
   Returns a preinitialized version of the AadHttpClient for a given resource url. For more information:
-  [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-aadhttpclient](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-aadhttpclient)
+  [https://learn.microsoft.com/sharepoint/dev/spfx/use-aadhttpclient](https://learn.microsoft.com/sharepoint/dev/spfx/use-aadhttpclient)
 remarks: >-
   The constructor for this class is marked as internal. Third-party code should not call the constructor directly or
   create subclasses that extend the `AadHttpClientFactory` class.

--- a/SP-Framework/sp-http/msgraphclientfactory.yml
+++ b/SP-Framework/sp-http/msgraphclientfactory.yml
@@ -5,7 +5,7 @@ package: '@microsoft/sp-http!'
 fullName: MSGraphClientFactory
 summary: >-
   Returns a preinitialized version of the MSGraphClient. For more information:
-  [https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-msgraph](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/use-msgraph)
+  [https://learn.microsoft.com/sharepoint/dev/spfx/use-msgraph](https://learn.microsoft.com/sharepoint/dev/spfx/use-msgraph)
 remarks: >-
   The constructor for this class is marked as internal. Third-party code should not call the constructor directly or
   create subclasses that extend the `MSGraphClientFactory` class.

--- a/SP-Framework/sp-webpart-base/imicrosoftteams.yml
+++ b/SP-Framework/sp-webpart-base/imicrosoftteams.yml
@@ -16,7 +16,7 @@ properties:
     summary: Microsoft Teams' Context.
     remarks: >-
       For more information, please see:
-      [https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/microsoftteams.context?view=msteams-client-js-latest](https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/microsoftteams.context?view=msteams-client-js-latest)
+      [https://learn.microsoft.com/javascript/api/@microsoft/teams-js/microsoftteams.context?view=msteams-client-js-latest](https://learn.microsoft.com/javascript/api/@microsoft/teams-js/microsoftteams.context?view=msteams-client-js-latest)
     isPreview: false
     isDeprecated: false
     syntax:

--- a/SP-Framework/sp-webpart-base/isdks.yml
+++ b/SP-Framework/sp-webpart-base/isdks.yml
@@ -18,7 +18,7 @@ properties:
       being hosted in Microsoft Teams.
     remarks: >-
       For more information, please see:
-      [https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest](https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
+      [https://learn.microsoft.com/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest](https://learn.microsoft.com/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
     isPreview: false
     isDeprecated: false
     syntax:

--- a/SP-Framework/sp-webpart-base/webpartcontext.yml
+++ b/SP-Framework/sp-webpart-base/webpartcontext.yml
@@ -34,7 +34,7 @@ properties:
       being hosted in Microsoft Teams.
     remarks: >-
       For more information, please see:
-      [https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest](https://docs.microsoft.com/en-us/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
+      [https://learn.microsoft.com/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest](https://learn.microsoft.com/javascript/api/@microsoft/teams-js/?view=msteams-client-js-latest)
     isPreview: false
     isDeprecated: true
     customDeprecatedMessage: '- This function has been deprecated'


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## What's in this Pull Request?

**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
