### PR TITLE
Update log.yml with new logging method details

### DIFF
--- a/SP-Framework/sp-core-library/log.yml
+++ b/SP-Framework/sp-core-library/log.yml
@@ -26,7 +26,7 @@ methods:
         - id: source
           description: >-
             the source from where the error is logged, e.g., the class name. The source provides context information for
-            the logged error. If the source's length is more than 20, only the first 20 characters are kept.
+            the logged error. If the source's length is more than 30, only the first 30 characters are kept.
           type: string
         - id: error
           description: the error to be logged
@@ -53,10 +53,10 @@ methods:
         - id: source
           description: >-
             the source from where the message is logged, e.g., the class name. The source provides context information
-            for the logged message. If the source's length is more than 20, only the first 20 characters are kept.
+            for the logged message. If the source's length is more than 30, only the first 30 characters are kept.
           type: string
         - id: message
-          description: 'the message to be logged If the message''s length is more than 100, only the first 100 characters are kept.'
+          description: 'the message to be logged If the message''s length is more than 150, only the first 150 characters are kept.'
           type: string
         - id: scope
           description: >-
@@ -80,10 +80,10 @@ methods:
         - id: source
           description: >-
             the source from where the message is logged, e.g., the class name. The source provides context information
-            for the logged message. If the source's length is more than 20, only the first 20 characters are kept.
+            for the logged message. If the source's length is more than 30, only the first 30 characters are kept.
           type: string
         - id: message
-          description: 'the message to be logged If the message''s length is more than 100, only the first 100 characters are kept.'
+          description: 'the message to be logged If the message''s length is more than 150, only the first 150 characters are kept.'
           type: string
         - id: scope
           description: >-
@@ -107,10 +107,10 @@ methods:
         - id: source
           description: >-
             the source from where the message is logged, e.g., the class name. The source provides context information
-            for the logged message. If the source's length is more than 20, only the first 20 characters are kept.
+            for the logged message. If the source's length is more than 30, only the first 30 characters are kept.
           type: string
         - id: message
-          description: 'the message to be logged If the message''s length is more than 100, only the first 100 characters are kept.'
+          description: 'the message to be logged If the message''s length is more than 150, only the first 150 characters are kept.'
           type: string
         - id: scope
           description: >-
@@ -120,3 +120,4 @@ methods:
       return:
         type: void
         description: ''
+


### PR DESCRIPTION
Updated characters limits for message and source properties.

Before it was reporting:
- 20 characters limit for source
- 100 characters limit for messages

Now the updated values are:
- 30 characters limit for source
- 150 characters limit for messages